### PR TITLE
Added support for padding with multi-character strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ leftpad('foobar', 6)
 leftpad(1, 2, 0)
 // => "01"
 ```
+
+## Instructions
+This module contains one function: leftpad . Leftpad has 3 parameters. The first pameter is mandatory and must be a variable whose type is convertable into a String by using the String constructor. The second parameter is the minimum length the String must be padded to. This is also mandatory, and must be an integer. The third parameter is the phrase to pad with. This is optional, and if present, must be a variable whose type is convertable into a String. By default, the third parameter is the first space character in Unicode. Note that if the result needs to be exactly the length specified in the second parameter, the third parameter must have a length of exactly one. Otherwise, the result may be longer than specified.

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function lp (str, len, ch) {
     return lp(str,len,' ');
   }
   str = String(str);
-  var padLen = (len-str.length)-1;
+  var padLen = (len-str.length);
   var padCount = Math.floor(padLen/ch.length);
   if((ch.length % padLen)==0) {
     return (treePad(ch, padCount)+str);

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function lp (str, len, ch) {
     return lp(str,len,' ');
   }
   str = String(str);
-  var padLen = len-str.length;
+  var padLen = (len-str.length)-1;
   var padCount = Math.floor(padLen/ch.length);
   if((ch.length % padLen)==0) {
     return (treePad(ch, padCount)+str);

--- a/index.js
+++ b/index.js
@@ -1,15 +1,29 @@
-module.exports = leftpad;
-
-function leftpad (str, len, ch) {
+function lp (str, len, ch) {
+  var treePad = function(phrase, count){
+    switch(count){
+      case 0: return "";
+      case 1: return phrase;
+      default:
+        if ((count%2)==0) {
+          var inter = treePad(phrase, count/2);
+          return (inter + inter);
+        }
+        if ((count%3)==0) {
+            var interm = treePad(phrase, count/3);
+            return (interm + interm + interm);
+        }
+        return (phrase + treePad(phrase, count-1));
+    }
+  };
+  if (ch==null) {
+    return lp(str,len,' ');
+  }
   str = String(str);
-
-  if (ch == null) {
-    ch = ' ';
+  var padLen = len-str.length;
+  var padCount = Math.floor(padLen/ch.length);
+  if((ch.length % padLen)==0) {
+    return (treePad(ch, padCount)+str);
   }
-
-  while (str.length < len) {
-    str = ch + str;
-  }
-
-  return str;
-}
+  return (treePad(ch, padCount+1)+str);
+};
+module.exports = lp;

--- a/index.js
+++ b/index.js
@@ -3,13 +3,11 @@ module.exports = leftpad;
 function leftpad (str, len, ch) {
   str = String(str);
 
-  var i = -1;
+  if (ch == null) {
+    ch = ' ';
+  }
 
-  if (!ch && ch !== 0) ch = ' ';
-
-  len = len - str.length;
-
-  while (++i < len) {
+  while (str.length < len) {
     str = ch + str;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "left-pad",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "String left pad",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In the previous version, if you tried to pad with a string other than a length of one, it would have unusual results.

`
var leftpad = require("left-pad");
console.log(leftpad("abcd", 26, "PP"));
`

Would result in "PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPabcd", not the logical "PPPPPPPPPPPPPPPPPPPPPPabcd". I fixed that. There's also some minor documentation changes.
